### PR TITLE
Add missed profile selection in one of the places

### DIFF
--- a/check-account-secrets.ps1
+++ b/check-account-secrets.ps1
@@ -44,7 +44,7 @@ if (-Not($Response.Account -eq $AccountID)) {
 Write-Output "List of ARNs missing secrets in Secrets Manager in account $($AccountID) with profile name $($ProfileName):"
 Write-Output "`n"
 
-(aws ec2 describe-regions | ConvertFrom-Json).Regions.RegionName | ForEach-Object -Parallel {
+(aws --profile "$ProfileName" ec2 describe-regions | ConvertFrom-Json).Regions.RegionName | ForEach-Object -Parallel {
     $EC2Instances = aws --region $_ --profile "$($using:ProfileName)" ec2 describe-instances | ConvertFrom-Json
     $EC2KeyPairARNs = @()
     $EC2InstanceARNs = @()


### PR DESCRIPTION
Original code throws this error when used with non-default profile
```
List of ARNs missing secrets in Secrets Manager in account 994672346694 with profile name saml:


aws : 
At C:\Projects\rob-moss-secrets-manager-scripts\check-account-secrets.ps1:47 char:2
+ (aws ec2 describe-regions | ConvertFrom-Json).Regions.RegionName | Fo ...
+  ~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
You must specify a region. You can also configure your region by running "aws configure".
```

Fixes #2 